### PR TITLE
Fix: Resolve blank book pages due to JavaScript Map serialization issue

### DIFF
--- a/src/app/book/[sectionSlug]/SectionPageClient.jsx
+++ b/src/app/book/[sectionSlug]/SectionPageClient.jsx
@@ -139,8 +139,8 @@ export default function SectionPageClient({ section, visuals, visualsMap, params
       const imageIdentifier = props.src;
       const normalizedIdentifier = imageIdentifier?.toString().toUpperCase().trim() || '';
       
-      // Use direct lookup in visualsMap
-      const visual = visualsMap?.get(normalizedIdentifier);
+      // Use direct lookup in visualsMap (now a plain object)
+      const visual = visualsMap?.[normalizedIdentifier];
 
       if (visual && visual.displayUrl) {
         return (

--- a/src/app/book/[sectionSlug]/page.js
+++ b/src/app/book/[sectionSlug]/page.js
@@ -164,7 +164,7 @@ export default async function SectionPage({ params }) {
 
     // Optimized visual processing with early returns
     let visualsWithUrls = [];
-    let visualsMap = new Map();
+    let visualsMap = {};
     
     if (visualsData.length > 0) {
       // Limit visual processing to prevent timeouts
@@ -175,11 +175,12 @@ export default async function SectionPage({ params }) {
         visualsWithUrls = await processVisualsOptimized(limitedVisuals);
         
         // Create visuals map for markdown rendering with normalized keys
+        // Use plain object instead of Map to avoid serialization issues
         visualsWithUrls.forEach(vis => {
           if (vis.markdown_tag && vis.displayUrl) {
             // Normalize the key on server side to avoid client-side processing
             const normalizedKey = vis.markdown_tag.toString().toUpperCase().trim();
-            visualsMap.set(normalizedKey, vis);
+            visualsMap[normalizedKey] = vis;
           }
         });
       } catch (error) {


### PR DESCRIPTION
## Problem
Four specific pages were showing blank screens due to a JavaScript Map serialization issue. The Map object cannot be properly serialized between server and client components in Next.js.

## Solution
- Changed `visualsMap` from a Map object to a plain JavaScript object in the server component (page.js)
- Updated the client component to use object notation (`visualsMap[key]`) instead of Map methods (`visualsMap.get(key)`)

## Files Changed
- `src/app/book/[sectionSlug]/page.js`: Updated to use plain object for visualsMap
- `src/app/book/[sectionSlug]/SectionPageClient.jsx`: Updated to access visualsMap properties using object notation

## Testing
- Verified that the previously blank pages now render correctly
- Confirmed that the serialization issue is resolved
- All previously failing pages now load correctly:
  * 01_intro_through_next_steps ✅
  * 02_kingdom_government ✅
  * 06_key_principles_01-10 ✅
  * 07_conclusion ✅

This fix ensures proper data flow between server and client components while maintaining the same functionality.