### PR TITLE
Fix project automation: query user project by default

### DIFF
--- a/.github/workflows/auto-move-project-cards.yml
+++ b/.github/workflows/auto-move-project-cards.yml
@@ -41,7 +41,7 @@ jobs:
             async function getProjectInfo() {
               const query = `
                 query($owner: String!, $number: Int!) {
-                  organization(login: $owner) {
+                  user(login: $owner) {
                     projectV2(number: $number) {
                       id
                       fields(first: 20) {
@@ -65,45 +65,11 @@ jobs:
                 }
               `;
               
-              try {
-                const result = await github.graphql(query, {
-                  owner: owner,
-                  number: 2
-                });
-                return result.organization.projectV2;
-              } catch (error) {
-                // Try user query if organization fails
-                const userQuery = `
-                  query($owner: String!, $number: Int!) {
-                    user(login: $owner) {
-                      projectV2(number: $number) {
-                        id
-                        fields(first: 20) {
-                          nodes {
-                            ... on ProjectV2Field {
-                              id
-                              name
-                            }
-                            ... on ProjectV2SingleSelectField {
-                              id
-                              name
-                              options {
-                                id
-                                name
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                `;
-                const userResult = await github.graphql(userQuery, {
-                  owner: owner,
-                  number: 2
-                });
-                return userResult.user.projectV2;
-              }
+              const result = await github.graphql(query, {
+                owner: owner,
+                number: 2
+              });
+              return result.user.projectV2;
             }
             
             // Function to get project items related to commits


### PR DESCRIPTION
## Problem
The GitHub Action workflow `auto-move-project-cards.yml` was failing with the error "Could not resolve to a ProjectV2" because it was attempting to query for an organization project when the repository `dramonfx/renewed-app-v2` is owned by a user account.

## Solution
This PR fixes the issue by:

- **Removing the organization query entirely** from the `getProjectInfo` function
- **Removing the try-catch block** that attempted organization query first and fell back to user query
- **Simplifying the function** to only use the user query as the default method

## Changes Made
- Modified `.github/workflows/auto-move-project-cards.yml`
- Updated the `getProjectInfo` function to use only the user GraphQL query:
  ```javascript
  async function getProjectInfo() {
    const query = `
      query($owner: String!, $number: Int!) {
        user(login: $owner) {
          projectV2(number: $number) {
            id
            fields(first: 20) {
              nodes {
                ... on ProjectV2Field {
                  id
                  name
                }
                ... on ProjectV2SingleSelectField {
                  id
                  name
                  options {
                    id
                    name
                  }
                }
              }
            }
          }
        }
      }
    `;
    
    const result = await github.graphql(query, {
      owner: owner,
      number: 2
    });
    return result.user.projectV2;
  }
  ```

## Testing
This change should resolve the workflow failures and allow the project automation to work correctly for user-owned repositories.

## Impact
- ✅ Fixes the "Could not resolve to a ProjectV2" error
- ✅ Simplifies the code by removing unnecessary complexity
- ✅ Makes the workflow more reliable for user-owned repositories